### PR TITLE
fix bogus default triggering mechanism for canbus::Task

### DIFF
--- a/canbus.orogen
+++ b/canbus.orogen
@@ -9,7 +9,6 @@ import_types_from "base_schilling/Error.hpp"
 task_context "Task" do
     doc "component that allows to demultiplex CAN messages from a single CAN bus, and monitor the bus health indicators. To use, one adds specific CAN messages to watch using watch(), and then connects to the port(s) created by watch()."
 
-    fd_driven
     needs_configuration
 
     property("device", "/std/string").
@@ -56,6 +55,7 @@ task_context "Task" do
         argument("name", "/std/string", "the name of the watched device to remove")
 
     port_driven
+    fd_driven
     exception_states :IO_ERROR
     error_states :CAN_ERROR
 end


### PR DESCRIPTION
The port_driven call cancels the fd_driven call, which means that
the canbus task was only port-driven (and not both port and fd-driven)
by default -- with the result of having a useless task.
