### PR TITLE
added property to configure dynamic ports

### DIFF
--- a/canTypes.hh
+++ b/canTypes.hh
@@ -17,6 +17,15 @@ namespace canbus
         Statistics()
             : msg_tx(0), msg_rx(0), tx(0), rx(0), error_count(0) {}
     };
+
+    struct CanOutputPort
+    {
+        std::string ports_name;
+        std::uint32_t mask;
+        std::uint32_t id;
+        CanOutputPort()
+            : mask(0), id(0) {}
+    };
 }
 #endif
 

--- a/canbus.orogen
+++ b/canbus.orogen
@@ -26,7 +26,7 @@ task_context "Task" do
     property("statsInterval", "int", 1000).
         doc "the interval in which the stats message is send. The unit is in ms"
 
-    property("output_portnames", "std/vector</std/string>").
+    property("outputPortnames", "std/vector</std/string>").
         doc "The component will create the necessary ports at configure time based on the port names that are listed in the configuration file"
 
     input_port("in", "/canbus/Message").

--- a/canbus.orogen
+++ b/canbus.orogen
@@ -26,6 +26,9 @@ task_context "Task" do
     property("statsInterval", "int", 1000).
         doc "the interval in which the stats message is send. The unit is in ms"
 
+    property("output_portnames", "std/vector</std/string>").
+        doc "The component will create the necessary ports at configure time based on the port names that are listed in the configuration file"
+
     input_port("in", "/canbus/Message").
         multiplexes.
         needs_reliable_connection.

--- a/canbus.orogen
+++ b/canbus.orogen
@@ -26,7 +26,7 @@ task_context "Task" do
     property("statsInterval", "int", 1000).
         doc "the interval in which the stats message is send. The unit is in ms"
 
-    property("outputPortnames", "std/vector</std/string>").
+    property("outputPorts", "std/vector</canbus/CanOutputPort>").
         doc "The component will create the necessary ports at configure time based on the port names that are listed in the configuration file"
 
     input_port("in", "/canbus/Message").

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -75,7 +75,7 @@ bool Task::configureHook()
     }
 
     // creating dynamic ports
-    std::vector<canbus::CanOutputPort> outputports(_outputPorts.get());
+    outputports = _outputPorts.get();
     for (size_t i = 0; i < outputports.size(); ++i)
     {
         canbus::CanOutputPort const& outputport(outputports[i]);
@@ -196,5 +196,19 @@ void Task::cleanupHook()
     m_driver->close();
     delete m_driver;
     m_driver = 0;
+    for (Mappings::const_iterator it = m_mappings.begin(); it != m_mappings.end(); ++it)
+    {
+        for (size_t i = 0; i < outputports.size(); ++i)
+        {
+            canbus::CanOutputPort const& outputport(outputports[i]);
+            if (it->output->getName() == outputport.ports_name)
+            {
+                m_mapping_cache.clear();
+                ports()->removePort(it->output->getName());
+                delete it->output;
+                m_mappings.erase(it);
+            }
+        }
+    }
     TaskBase::cleanupHook();
 }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -74,6 +74,21 @@ bool Task::configureHook()
         return false;
     }
 
+    // creating dynamic ports
+    std::vector<std::string> portnames(_output_portnames.get());
+    for (size_t i = 0; i < portnames.size(); ++i)
+    {
+        std::string const& portname(portnames[i]);
+        if (ports()->getPort(portname))
+        {
+            RTT::log(RTT::Error) << "output port " <<  portname << " is listed more than once in the outputs configuration property" << RTT::endlog();
+            // ports()->clearPorts();
+            return false;
+        }
+        RTT::OutputPort<canbus::Message>* output_port = new RTT::OutputPort<canbus::Message>(portname);
+        ports()->addPort(portname, *output_port);
+    }
+   
     m_can_check_interval = base::Time::fromMicroseconds(_checkBusOkInterval.get() * 1000);
     m_stats_interval = base::Time::fromMicroseconds(_statsInterval.get() * 1000);
     return true;

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -75,7 +75,7 @@ bool Task::configureHook()
     }
 
     // creating dynamic ports
-    outputports = _outputPorts.get();
+    std::vector<canbus::CanOutputPort> outputports = _outputPorts.get();
     for (size_t i = 0; i < outputports.size(); ++i)
     {
         canbus::CanOutputPort const& outputport(outputports[i]);

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -75,18 +75,22 @@ bool Task::configureHook()
     }
 
     // creating dynamic ports
-    std::vector<std::string> portnames(_output_portnames.get());
+    std::vector<std::string> portnames(_outputPortnames.get());
     for (size_t i = 0; i < portnames.size(); ++i)
     {
         std::string const& portname(portnames[i]);
         if (ports()->getPort(portname))
         {
             RTT::log(RTT::Error) << "output port " <<  portname << " is listed more than once in the outputs configuration property" << RTT::endlog();
-            // ports()->clearPorts();
             return false;
         }
         RTT::OutputPort<canbus::Message>* output_port = new RTT::OutputPort<canbus::Message>(portname);
         ports()->addPort(portname, *output_port);
+        // register the mapping
+        std::uint32_t id  = 0;
+        std::uint32_t mask = 0;
+        Mapping mapping = { portname, id & mask, mask, output_port };
+        m_mappings.push_back(mapping);
     }
    
     m_can_check_interval = base::Time::fromMicroseconds(_checkBusOkInterval.get() * 1000);

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -196,22 +196,17 @@ void Task::cleanupHook()
     m_driver->close();
     delete m_driver;
     m_driver = 0;
-    for (Mappings::const_iterator it = m_mappings.begin(); it != m_mappings.end(); ++it)
+    for (Mappings::const_iterator it = m_mappings.begin(); it != m_mappings.end();)
     {
-        for (size_t i = 0; i < outputports.size(); ++i)
+        if (it->remove_on_cleanup)
         {
-            canbus::CanOutputPort const& outputport(outputports[i]);
-            if (it->output->getName() == outputport.ports_name)
-            {
-                if (it->remove_on_cleanup)
-                {
-                m_mapping_cache.clear();
-                ports()->removePort(it->output->getName());
-                delete it->output;
-                m_mappings.erase(it);
-                }
-            }
+            m_mapping_cache.clear();
+            ports()->removePort(it->output->getName());
+            delete it->output;
+            it = m_mappings.erase(it);
         }
+        else 
+            ++it;
     }
     TaskBase::cleanupHook();
 }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -42,7 +42,7 @@ bool Task::watch(std::string const& name, int id, int mask)
     ports()->addPort(name, *output_port);
 
     // And register the mapping
-    Mapping mapping = { name, id & mask, mask, output_port };
+    Mapping mapping = { name, id & mask, mask, false, output_port };
     m_mappings.push_back(mapping);
 
     return true;
@@ -87,7 +87,7 @@ bool Task::configureHook()
         RTT::OutputPort<canbus::Message>* new_output_port = new RTT::OutputPort<canbus::Message>(outputport.ports_name);
         ports()->addPort(outputport.ports_name, *new_output_port);
         // register the mapping
-        Mapping mapping = { outputport.ports_name, outputport.id & outputport.mask, outputport.mask, new_output_port };
+        Mapping mapping = { outputport.ports_name, outputport.id & outputport.mask, outputport.mask, true, new_output_port };
         m_mappings.push_back(mapping);
     }
    
@@ -203,10 +203,13 @@ void Task::cleanupHook()
             canbus::CanOutputPort const& outputport(outputports[i]);
             if (it->output->getName() == outputport.ports_name)
             {
+                if (it->remove_on_cleanup)
+                {
                 m_mapping_cache.clear();
                 ports()->removePort(it->output->getName());
                 delete it->output;
                 m_mappings.erase(it);
+                }
             }
         }
     }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -75,21 +75,19 @@ bool Task::configureHook()
     }
 
     // creating dynamic ports
-    std::vector<std::string> portnames(_outputPortnames.get());
-    for (size_t i = 0; i < portnames.size(); ++i)
+    std::vector<canbus::CanOutputPort> outputports(_outputPorts.get());
+    for (size_t i = 0; i < outputports.size(); ++i)
     {
-        std::string const& portname(portnames[i]);
-        if (ports()->getPort(portname))
+        canbus::CanOutputPort const& outputport(outputports[i]);
+        if (ports()->getPort(outputport.ports_name))
         {
-            RTT::log(RTT::Error) << "output port " <<  portname << " is listed more than once in the outputs configuration property" << RTT::endlog();
+            RTT::log(RTT::Error) << "output port " <<  outputport.ports_name << " is listed more than once in the outputs configuration property" << RTT::endlog();
             return false;
         }
-        RTT::OutputPort<canbus::Message>* output_port = new RTT::OutputPort<canbus::Message>(portname);
-        ports()->addPort(portname, *output_port);
+        RTT::OutputPort<canbus::Message>* new_output_port = new RTT::OutputPort<canbus::Message>(outputport.ports_name);
+        ports()->addPort(outputport.ports_name, *new_output_port);
         // register the mapping
-        std::uint32_t id  = 0;
-        std::uint32_t mask = 0;
-        Mapping mapping = { portname, id & mask, mask, output_port };
+        Mapping mapping = { outputport.ports_name, outputport.id & outputport.mask, outputport.mask, new_output_port };
         m_mappings.push_back(mapping);
     }
    

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -47,7 +47,6 @@ namespace canbus {
 
         base::Time m_can_check_interval;
         base::Time m_stats_interval;
-        std::vector<canbus::CanOutputPort> outputports;
 
     public:
         Task(std::string const& name = "canbus::Task");

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -26,6 +26,7 @@ namespace canbus {
             std::string name;
             uint32_t id;
             uint32_t mask;
+            bool remove_on_cleanup;
             RTT::OutputPort<canbus::Message>* output;
         };
         typedef std::vector<Mapping> Mappings;

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -46,6 +46,7 @@ namespace canbus {
 
         base::Time m_can_check_interval;
         base::Time m_stats_interval;
+        std::vector<canbus::CanOutputPort> outputports;
 
     public:
         Task(std::string const& name = "canbus::Task");


### PR DESCRIPTION
The dynamic ports of the Canbus have to be configured before connecting with any other driver. So a new property is added to the canbus component.