### PR TITLE
fix: make the hardcoded FD activity timeout configurable

### DIFF
--- a/canbus.orogen
+++ b/canbus.orogen
@@ -29,6 +29,11 @@ task_context "Task" do
     property("outputPorts", "std/vector</canbus/CanOutputPort>").
         doc "The component will create the necessary ports at configure time based on the port names that are listed in the configuration file"
 
+    # What timeout value should be set for the underlying FD activity (if fd_driven)
+    #
+    # This should be lower than the statsInterval and checkBusOkInterval
+    property "fd_activity_timeout", "/base/Time"
+
     input_port("in", "/canbus/Message").
         multiplexes.
         needs_reliable_connection.

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -10,9 +10,10 @@
 using namespace canbus;
 
 Task::Task(std::string const& name)
-: TaskBase(name)
-, m_driver(NULL)
+    : TaskBase(name)
+    , m_driver(NULL)
 {
+    _fd_activity_timeout = base::Time::fromMilliseconds(100);
 }
 
 Task::~Task()
@@ -103,7 +104,7 @@ bool Task::startHook()
     if (fd_activity)
     {
         fd_activity->watch(m_driver->getFileDescriptor());
-        fd_activity->setTimeout(100);
+        fd_activity->setTimeout(_fd_activity_timeout.get().toMilliseconds());
     }
 
     if (!m_driver->reset())


### PR DESCRIPTION
The current value is 100ms, which leads to MANY timeout messages in case the underlying bus is expected to get data at a lower rate (we're having a bus with messages every ~1s).