### PR TITLE
Update canTypes.hh

### DIFF
--- a/canTypes.hh
+++ b/canTypes.hh
@@ -2,6 +2,8 @@
 #define CANBUS_TYPES_HH
 
 #include <base/Time.hpp>
+#include <cstdint>
+#include <string>
 
 namespace canbus
 {


### PR DESCRIPTION
Fix for

```
/opt/workspace/drivers/orogen/canbus/.orogen/typekit/types/canbus/canTypes.hh:24:9: error: no type named 'uint32_t' in namespace 'std'; did you mean simply 'uint32_t'?
   24 |         std::uint32_t mask;
      |         ^~~~~~~~~~~~~
      |         uint32_t
/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h:26:20: note: 'uint32_t' declared here
   26 | typedef __uint32_t uint32_t;
      |                    ^
/opt/workspace/drivers/orogen/canbus/.orogen/typekit/types/canbus/canTypes.hh:25:9: error: no type named 'uint32_t' in namespace 'std'; did you mean simply 'uint32_t'?
   25 |         std::uint32_t id;
      |         ^~~~~~~~~~~~~
      |         uint32_t
/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h:26:20: note: 'uint32_t' declared here
   26 | typedef __uint32_t uint32_t;
```